### PR TITLE
Add basic Einstein Chat LWC component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# lwc-ai
+# LWC AI Chatbot
+
+This repository contains a minimal Lightning Web Component (LWC) that serves as a starting point for building an Einstein AI chatbot. The component lives in the `einsteinChat` directory and includes basic markup, styles and JavaScript.
+
+## Component Structure
+
+```
+einsteinChat/
+├── einsteinChat.html
+├── einsteinChat.js
+├── einsteinChat.js-meta.xml
+└── einsteinChat.css
+```
+
+The component renders a simple chat window with an input field and a send button. Messages typed in the input are appended to the message list. You can extend this logic to integrate with your own chatbot service.
+
+## Usage
+
+Include the `einsteinChat` component in your Salesforce DX project or any environment that supports Lightning Web Components. Customize the JavaScript logic to call your chatbot backend and display responses in the message list.

--- a/einsteinChat/einsteinChat.css
+++ b/einsteinChat/einsteinChat.css
@@ -1,0 +1,28 @@
+.chat-container {
+    border: 1px solid #ccc;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    height: 300px;
+}
+
+.messages {
+    flex: 1;
+    overflow-y: auto;
+    margin-bottom: 1rem;
+    list-style: none;
+    padding: 0;
+}
+
+.message {
+    margin-bottom: 0.5rem;
+}
+
+.input-area {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.send-button {
+    align-self: flex-end;
+}

--- a/einsteinChat/einsteinChat.html
+++ b/einsteinChat/einsteinChat.html
@@ -1,0 +1,13 @@
+<template>
+    <div class="chat-container">
+        <ul class="messages">
+            <template for:each={messages} for:item="msg">
+                <li key={msg} class="message">{msg}</li>
+            </template>
+        </ul>
+        <div class="input-area">
+            <lightning-input label="Message" value={currentMessage} onchange={handleInputChange}></lightning-input>
+            <lightning-button label="Send" onclick={handleSend} class="send-button"></lightning-button>
+        </div>
+    </div>
+</template>

--- a/einsteinChat/einsteinChat.js
+++ b/einsteinChat/einsteinChat.js
@@ -1,0 +1,17 @@
+import { LightningElement, track } from 'lwc';
+
+export default class EinsteinChat extends LightningElement {
+    @track currentMessage = '';
+    @track messages = [];
+
+    handleInputChange(event) {
+        this.currentMessage = event.target.value;
+    }
+
+    handleSend() {
+        if (this.currentMessage) {
+            this.messages = [...this.messages, this.currentMessage];
+            this.currentMessage = '';
+        }
+    }
+}

--- a/einsteinChat/einsteinChat.js-meta.xml
+++ b/einsteinChat/einsteinChat.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata" fqn="einsteinChat">
+    <apiVersion>58.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- flesh out README with component info
- add initial Einstein Chat Lightning Web Component
- include meta file so the component can be used in a project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68651622302883248afb0339624491f0